### PR TITLE
Using the encoder on state is too broad.

### DIFF
--- a/ParseLiveQuery/src/main/java/com/parse/SubscribeClientOperation.java
+++ b/ParseLiveQuery/src/main/java/com/parse/SubscribeClientOperation.java
@@ -22,7 +22,14 @@ import org.json.JSONObject;
         jsonObject.put("requestId", requestId);
         jsonObject.put("sessionToken", sessionToken);
 
-        JSONObject queryJsonObject = state.toJSON(PointerEncoder.get());
+        JSONObject queryJsonObject = new JSONObject();
+        queryJsonObject.put("className", state.className());
+
+        // TODO: add support for fields
+        // https://github.com/ParsePlatform/parse-server/issues/3671
+        
+        PointerEncoder pointerEncoder = PointerEncoder.get();
+        queryJsonObject.put("where", pointerEncoder.encode(state.constraints()));
 
         jsonObject.put("query", queryJsonObject);
 

--- a/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
+++ b/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
@@ -116,7 +116,7 @@ public class TestParseLiveQueryClient {
     @Test
     public void testErrorWhileSubscribing() throws Exception {
         ParseQuery.State state = mock(ParseQuery.State.class);
-        when(state.toJSON(any(ParseEncoder.class))).thenThrow(new RuntimeException("forced error"));
+        when(state.constraints()).thenThrow(new RuntimeException("forced error"));
 
         ParseQuery.State.Builder builder = mock(ParseQuery.State.Builder.class);
         when(builder.build()).thenReturn(state);


### PR DESCRIPTION
Related to issue: https://github.com/ParsePlatform/ParseLiveQuery-Android/issues/14

Currently only the conditions and class name are encoded:

https://github.com/ParsePlatform/ParseLiveQuery-iOS-OSX/blob/master/Sources/ParseLiveQuery/Internal/QueryEncoder.swift

Based obviously on: https://github.com/ParsePlatform/parse-server/wiki/Parse-LiveQuery-Protocol-Specification

@mmimeault @flovilmart 