### PR TITLE
Fix #21: connect and disconnect on the background executor

### DIFF
--- a/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientImpl.java
+++ b/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientImpl.java
@@ -88,19 +88,21 @@ import static com.parse.Parse.checkInit;
 
     @Override
     public void reconnect() {
-        if (webSocketClient != null) {
-            webSocketClient.close();
-        }
-        this.webSocketClient = webSocketClientFactory.createInstance(webSocketClientCallback, uri);
-        this.webSocketClient.open();
+        disconnectAsync().continueWith(new Continuation<Void, Void>() {
+            @Override
+            public Void then(Task<Void> task) throws Exception {
+                webSocketClient = webSocketClientFactory.createInstance(webSocketClientCallback, uri);
+                webSocketClient.open();
+                return null;
+            }
+        });
         userInitiatedDisconnect = false;
     }
 
     @Override
     public void disconnect() {
         if (webSocketClient != null) {
-            webSocketClient.close();
-            webSocketClient = null;
+            disconnectAsync();
             userInitiatedDisconnect = true;
         }
     }
@@ -126,6 +128,20 @@ import static com.parse.Parse.checkInit;
                 JSONObject jsonEncoded = clientOperation.getJSONObjectRepresentation();
                 String jsonString = jsonEncoded.toString();
                 webSocketClient.send(jsonString);
+                return null;
+            }
+        }, taskExecutor);
+    }
+
+    private Task<Void> disconnectAsync() {
+        return Task.call(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                if (webSocketClient != null) {
+                    webSocketClient.close();
+                    webSocketClient = null;
+                }
+
                 return null;
             }
         }, taskExecutor);
@@ -227,7 +243,7 @@ import static com.parse.Parse.checkInit;
             public Void then(Task<String> task) throws Exception {
                 String sessionToken = task.getResult();
                 SubscribeClientOperation<T> op = new SubscribeClientOperation<>(subscription.getRequestId(), subscription.getQueryState(), sessionToken);
-                
+
                 // dispatch errors
                 sendOperationAsync(op).continueWith(new Continuation<Void, Void>() {
                     public Void then(Task<Void> task) {

--- a/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
+++ b/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
@@ -13,6 +13,8 @@ import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.net.URI;
+import java.util.LinkedList;
+import java.util.Queue;
 import java.util.concurrent.Executor;
 
 import bolts.Task;
@@ -23,8 +25,8 @@ import static junit.framework.Assert.assertTrue;
 import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.contains;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -345,6 +347,28 @@ public class TestParseLiveQueryClient {
                 contains("\"sessionToken\":\"the token\"")));
     }
 
+    @Test
+    public void testDisconnectOnBackgroundThread() throws Exception {
+        PauseableExecutor executor = new PauseableExecutor();
+        // Recreate the client with a PauseableExecutor
+        parseLiveQueryClient = ParseLiveQueryClient.Factory.getClient(new URI(""), new WebSocketClientFactory() {
+            @Override
+            public WebSocketClient createInstance(WebSocketClient.WebSocketClientCallback webSocketClientCallback, URI hostUrl) {
+                TestParseLiveQueryClient.this.webSocketClientCallback = webSocketClientCallback;
+                webSocketClient = mock(WebSocketClient.class);
+                return webSocketClient;
+            }
+        }, executor);
+
+        reconnect();
+        executor.pause();
+
+        parseLiveQueryClient.disconnect();
+        verify(webSocketClient, never()).close();
+        assertTrue(executor.advanceOne());
+        verify(webSocketClient, times(1)).close();
+    }
+
     private SubscriptionHandling<ParseObject> createSubscription(ParseQuery<ParseObject> parseQuery,
             SubscriptionHandling.HandleSubscribeCallback<ParseObject> subscribeMockCallback) throws Exception {
         SubscriptionHandling<ParseObject> subscriptionHandling = parseLiveQueryClient.subscribe(parseQuery).handleSubscribe(subscribeMockCallback);
@@ -442,5 +466,40 @@ public class TestParseLiveQueryClient {
         jsonObject.put("requestId", requestId);
         jsonObject.put("object", PointerEncoder.get().encodeRelatedObject(parseObject));
         return jsonObject;
+    }
+
+    private static class PauseableExecutor implements Executor {
+        private boolean isPaused = false;
+        private final Queue<Runnable> queue = new LinkedList<>();
+
+        void pause() {
+            isPaused = true;
+        }
+
+        void unpause() {
+            if (isPaused) {
+                isPaused = false;
+
+                //noinspection StatementWithEmptyBody
+                while (advanceOne()) {
+                    // keep going
+                }
+            }
+        }
+
+        boolean advanceOne() {
+            Runnable next = queue.poll();
+            if (next != null) next.run();
+            return next != null;
+        }
+
+        @Override
+        public void execute(Runnable runnable) {
+            if (isPaused) {
+                queue.add(runnable);
+            } else {
+                runnable.run();
+            }
+        }
     }
 }


### PR DESCRIPTION
TubeSock already uses a background thread for `open()`, but it keeps the
`close()` call on the calling thread. So `open()` is safe on the main thread,
but `close()` is not.