### PR TITLE
Log outgoing JSON

### DIFF
--- a/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientImpl.java
+++ b/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientImpl.java
@@ -125,6 +125,9 @@ import static com.parse.Parse.checkInit;
             public Void call() throws Exception {
                 JSONObject jsonEncoded = clientOperation.getJSONObjectRepresentation();
                 String jsonString = jsonEncoded.toString();
+                if (Parse.getLogLevel() <= Parse.LOG_LEVEL_DEBUG) {
+                    Log.d(LOG_TAG, "Sending over websocket: " + jsonString);
+                }
                 webSocketClient.send(jsonString);
                 return null;
             }


### PR DESCRIPTION
This may become unnecessary if/when we move to OkHttp3 (#19). But for now
it's the only way to see the exact JSON data that is being sent over the
websocket.