### PR TITLE
Refactor the client's generic type parameters

### DIFF
--- a/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClient.java
+++ b/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClient.java
@@ -3,13 +3,13 @@ package com.parse;
 import java.net.URI;
 import java.util.concurrent.Executor;
 
-public interface ParseLiveQueryClient<T extends ParseObject> {
+public interface ParseLiveQueryClient {
 
-    SubscriptionHandling<T> subscribe(ParseQuery<T> query);
+    <T extends ParseObject> SubscriptionHandling<T> subscribe(ParseQuery<T> query);
 
-    void unsubscribe(final ParseQuery<T> query);
+    <T extends ParseObject> void unsubscribe(final ParseQuery<T> query);
 
-    void unsubscribe(final ParseQuery<T> query, final SubscriptionHandling subscriptionHandling);
+    <T extends ParseObject> void unsubscribe(final ParseQuery<T> query, final SubscriptionHandling<T> subscriptionHandling);
 
     void reconnect();
 
@@ -17,13 +17,13 @@ public interface ParseLiveQueryClient<T extends ParseObject> {
 
     class Factory {
 
-        public static <T extends ParseObject> ParseLiveQueryClient<T> getClient(URI uri) {
-            return new ParseLiveQueryClientImpl<>(uri);
+        public static ParseLiveQueryClient getClient(URI uri) {
+            return new ParseLiveQueryClientImpl(uri);
         }
 
         /* package */
-        static <T extends ParseObject> ParseLiveQueryClient<T> getClient(URI uri, WebSocketClientFactory webSocketClientFactory, Executor taskExecutor) {
-            return new ParseLiveQueryClientImpl<>(uri, webSocketClientFactory, taskExecutor);
+        static ParseLiveQueryClient getClient(URI uri, WebSocketClientFactory webSocketClientFactory, Executor taskExecutor) {
+            return new ParseLiveQueryClientImpl(uri, webSocketClientFactory, taskExecutor);
         }
 
     }

--- a/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
+++ b/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
@@ -164,6 +164,48 @@ public class TestParseLiveQueryClient {
     }
 
     @Test
+    public void testHeterogeneousSubscriptions() throws Exception {
+        ParseObject.registerSubclass(MockClassA.class);
+        ParseObject.registerSubclass(MockClassB.class);
+
+        ParseQuery<MockClassA> query1 = ParseQuery.getQuery(MockClassA.class);
+        ParseQuery<MockClassB> query2 = ParseQuery.getQuery(MockClassB.class);
+        SubscriptionHandling<MockClassA> handle1 = parseLiveQueryClient.subscribe((ParseQuery) query1);
+        SubscriptionHandling<MockClassB> handle2 = parseLiveQueryClient.subscribe((ParseQuery) query2);
+
+        handle1.handleError(new SubscriptionHandling.HandleErrorCallback<MockClassA>() {
+            @Override
+            public void onError(ParseQuery<MockClassA> query, LiveQueryException exception) {
+                throw new RuntimeException(exception);
+            }
+        });
+        handle2.handleError(new SubscriptionHandling.HandleErrorCallback<MockClassB>() {
+            @Override
+            public void onError(ParseQuery<MockClassB> query, LiveQueryException exception) {
+                throw new RuntimeException(exception);
+            }
+        });
+
+        SubscriptionHandling.HandleEventCallback<MockClassA> eventMockCallback1 = mock(SubscriptionHandling.HandleEventCallback.class);
+        SubscriptionHandling.HandleEventCallback<MockClassB> eventMockCallback2 = mock(SubscriptionHandling.HandleEventCallback.class);
+
+        handle1.handleEvent(SubscriptionHandling.Event.CREATE, eventMockCallback1);
+        handle2.handleEvent(SubscriptionHandling.Event.CREATE, eventMockCallback2);
+
+        ParseObject parseObject1 = new MockClassA();
+        parseObject1.setObjectId("testId1");
+
+        ParseObject parseObject2 = new MockClassB();
+        parseObject2.setObjectId("testId2");
+
+        webSocketClientCallback.onMessage(createObjectCreateMessage(handle1.getRequestId(), parseObject1).toString());
+        webSocketClientCallback.onMessage(createObjectCreateMessage(handle2.getRequestId(), parseObject2).toString());
+
+        validateSameObject((SubscriptionHandling.HandleEventCallback) eventMockCallback1, (ParseQuery) query1, parseObject1);
+        validateSameObject((SubscriptionHandling.HandleEventCallback) eventMockCallback2, (ParseQuery) query2, parseObject2);
+    }
+
+    @Test
     public void testCreateEventWhenSubscribedToCallback() throws Exception {
         ParseQuery<ParseObject> parseQuery = new ParseQuery<>("test");
         SubscriptionHandling<ParseObject> subscriptionHandling = createSubscription(parseQuery,
@@ -370,6 +412,7 @@ public class TestParseLiveQueryClient {
 
         ParseObject newParseObject = objectCaptor.getValue();
 
+        assertEquals(originalParseObject.getClassName(), newParseObject.getClassName());
         assertEquals(originalParseObject.getObjectId(), newParseObject.getObjectId());
     }
 
@@ -487,5 +530,13 @@ public class TestParseLiveQueryClient {
                 runnable.run();
             }
         }
+    }
+
+    @ParseClassName("MockA")
+    static class MockClassA extends ParseObject {
+    }
+
+    @ParseClassName("MockB")
+    static class MockClassB extends ParseObject {
     }
 }

--- a/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
+++ b/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricGradleTestRunner;
@@ -42,7 +43,7 @@ public class TestParseLiveQueryClient {
     private PauseableExecutor executor;
     private WebSocketClient webSocketClient;
     private WebSocketClient.WebSocketClientCallback webSocketClientCallback;
-    private ParseLiveQueryClient<ParseObject> parseLiveQueryClient;
+    private ParseLiveQueryClient parseLiveQueryClient;
 
     private ParseUser mockUser;
 
@@ -170,8 +171,8 @@ public class TestParseLiveQueryClient {
 
         ParseQuery<MockClassA> query1 = ParseQuery.getQuery(MockClassA.class);
         ParseQuery<MockClassB> query2 = ParseQuery.getQuery(MockClassB.class);
-        SubscriptionHandling<MockClassA> handle1 = parseLiveQueryClient.subscribe((ParseQuery) query1);
-        SubscriptionHandling<MockClassB> handle2 = parseLiveQueryClient.subscribe((ParseQuery) query2);
+        SubscriptionHandling<MockClassA> handle1 = parseLiveQueryClient.subscribe(query1);
+        SubscriptionHandling<MockClassB> handle2 = parseLiveQueryClient.subscribe(query2);
 
         handle1.handleError(new SubscriptionHandling.HandleErrorCallback<MockClassA>() {
             @Override


### PR DESCRIPTION
The way it was written, a single client could only ever be used for a single
`<T extends ParseObject>` type parameter. That means to have multiple
LiveQuery objects for multiple ParseObject classes, we're forced to create
multiple ParseLiveQueryClient objects, each with its own `<T>` type parameter.

Since the client itself does not actually require being locked to a single
type, we can move those type parameters to individual methods instead.

The unit test _does not_ fail before or after the test, but this is more of a change of convenience.