### PR TITLE
Bump to 1.14.1

### DIFF
--- a/ParseLiveQuery/build.gradle
+++ b/ParseLiveQuery/build.gradle
@@ -40,7 +40,7 @@ android {
 }
 
 dependencies {
-    compile 'com.parse:parse-android:1.14.0'
+    compile 'com.parse:parse-android:1.14.1'
     compile 'com.squareup.okhttp3:okhttp:3.6.0'
     compile 'com.parse.bolts:bolts-tasks:1.4.0'
 


### PR DESCRIPTION
v1.14.0 version had checkInit() function that required clientKey to be set
https://github.com/ParsePlatform/Parse-SDK-Android/pull/613

@jhansche @mmimeault 