### PR TITLE
Add callbacks to be notified of connect/disconnect/error events

### DIFF
--- a/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClient.java
+++ b/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClient.java
@@ -14,6 +14,10 @@ public interface ParseLiveQueryClient {
 
     void disconnect();
 
+    void registerListener(ParseLiveQueryClientCallbacks listener);
+
+    void unregisterListener(ParseLiveQueryClientCallbacks listener);
+
     class Factory {
 
         public static ParseLiveQueryClient getClient() {
@@ -38,5 +42,4 @@ public interface ParseLiveQueryClient {
         }
 
     }
-
 }

--- a/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientCallbacks.java
+++ b/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientCallbacks.java
@@ -1,0 +1,11 @@
+package com.parse;
+
+public interface ParseLiveQueryClientCallbacks {
+    void onLiveQueryClientConnected(ParseLiveQueryClient client);
+
+    void onLiveQueryClientDisconnected(ParseLiveQueryClient client);
+
+    void onLiveQueryError(ParseLiveQueryClient client, LiveQueryException reason);
+
+    void onSocketError(ParseLiveQueryClient client, Throwable reason);
+}


### PR DESCRIPTION
This enables a partial fix/workaround for #6, which otherwise wouldn't even
be possible in its current state.

Future changes will allow the client to automatically reconnect when the
connection has been broken for any reason other than explicit disconnect().