### PR TITLE
Dispatch better disconnect events

### DIFF
--- a/ParseLiveQuery/src/main/java/com/parse/OkHttp3SocketClientFactory.java
+++ b/ParseLiveQuery/src/main/java/com/parse/OkHttp3SocketClientFactory.java
@@ -29,7 +29,7 @@ import okio.ByteString;
         return new OkHttp3WebSocketClient(mClient, webSocketClientCallback, hostUrl);
     }
 
-    class OkHttp3WebSocketClient implements WebSocketClient {
+    static class OkHttp3WebSocketClient implements WebSocketClient {
 
         private static final String LOG_TAG = "OkHttpWebSocketClient";
 
@@ -38,7 +38,7 @@ import okio.ByteString;
         private State state = State.NONE;
         private final OkHttpClient client;
         private final String url;
-        private final int STATUS_CODE = 200;
+        private final int STATUS_CODE = 1000;
         private final String CLOSING_MSG = "User invoked close";
 
         private final WebSocketListener handler = new WebSocketListener() {

--- a/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientCallbacks.java
+++ b/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientCallbacks.java
@@ -3,7 +3,7 @@ package com.parse;
 public interface ParseLiveQueryClientCallbacks {
     void onLiveQueryClientConnected(ParseLiveQueryClient client);
 
-    void onLiveQueryClientDisconnected(ParseLiveQueryClient client);
+    void onLiveQueryClientDisconnected(ParseLiveQueryClient client, boolean userInitiated);
 
     void onLiveQueryError(ParseLiveQueryClient client, LiveQueryException reason);
 

--- a/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientImpl.java
+++ b/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientImpl.java
@@ -138,8 +138,8 @@ import static com.parse.Parse.checkInit;
     @Override
     public void disconnect() {
         if (webSocketClient != null) {
-            disconnectAsync();
             userInitiatedDisconnect = true;
+            disconnectAsync();
         }
     }
 
@@ -254,7 +254,7 @@ import static com.parse.Parse.checkInit;
 
     private void dispatchDisconnected() {
         for (ParseLiveQueryClientCallbacks callback : mCallbacks) {
-            callback.onLiveQueryClientDisconnected(this);
+            callback.onLiveQueryClientDisconnected(this, userInitiatedDisconnect);
         }
     }
 

--- a/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientImpl.java
+++ b/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientImpl.java
@@ -266,9 +266,13 @@ import static com.parse.Parse.checkInit;
     }
 
     private void dispatchSocketError(Throwable reason) {
+        userInitiatedDisconnect = false;
+
         for (ParseLiveQueryClientCallbacks callback : mCallbacks) {
             callback.onSocketError(this, reason);
         }
+
+        dispatchDisconnected();
     }
 
     private <T extends ParseObject> void handleSubscribedEvent(JSONObject jsonObject) throws JSONException {

--- a/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
+++ b/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
@@ -400,7 +400,7 @@ public class TestParseLiveQueryClient {
     }
 
     @Test
-    public void testCallbackNotifiedOnDisconnect() throws Exception {
+    public void testCallbackNotifiedOnUnexpectedDisconnect() throws Exception {
         LoggingCallbacks callbacks = new LoggingCallbacks();
         parseLiveQueryClient.registerListener(callbacks);
         callbacks.transcript.assertNoEventsSoFar();
@@ -410,9 +410,8 @@ public class TestParseLiveQueryClient {
         callbacks.transcript.assertEventsSoFar("onLiveQueryClientDisconnected: false");
     }
 
-
     @Test
-    public void testCallbackNotifiedOnDisconnect_expected() throws Exception {
+    public void testCallbackNotifiedOnExpectedDisconnect() throws Exception {
         LoggingCallbacks callbacks = new LoggingCallbacks();
         parseLiveQueryClient.registerListener(callbacks);
         callbacks.transcript.assertNoEventsSoFar();

--- a/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
+++ b/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
@@ -443,7 +443,8 @@ public class TestParseLiveQueryClient {
         callbacks.transcript.assertNoEventsSoFar();
 
         webSocketClientCallback.onError(new IOException("bad things happened"));
-        callbacks.transcript.assertEventsSoFar("onSocketError: java.io.IOException: bad things happened");
+        callbacks.transcript.assertEventsSoFar("onSocketError: java.io.IOException: bad things happened",
+                "onLiveQueryClientDisconnected: false");
     }
 
     @Test

--- a/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
+++ b/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
@@ -405,8 +405,25 @@ public class TestParseLiveQueryClient {
         parseLiveQueryClient.registerListener(callbacks);
         callbacks.transcript.assertNoEventsSoFar();
 
+        // Unexpected close from the server:
         webSocketClientCallback.onClose();
-        callbacks.transcript.assertEventsSoFar("onLiveQueryClientDisconnected");
+        callbacks.transcript.assertEventsSoFar("onLiveQueryClientDisconnected: false");
+    }
+
+
+    @Test
+    public void testCallbackNotifiedOnDisconnect_expected() throws Exception {
+        LoggingCallbacks callbacks = new LoggingCallbacks();
+        parseLiveQueryClient.registerListener(callbacks);
+        callbacks.transcript.assertNoEventsSoFar();
+
+        parseLiveQueryClient.disconnect();
+        verify(webSocketClient, times(1)).close();
+
+        callbacks.transcript.assertNoEventsSoFar();
+        // the client is a mock, so it won't actually invoke the callback automatically
+        webSocketClientCallback.onClose();
+        callbacks.transcript.assertEventsSoFar("onLiveQueryClientDisconnected: true");
     }
 
     @Test
@@ -548,8 +565,8 @@ public class TestParseLiveQueryClient {
         }
 
         @Override
-        public void onLiveQueryClientDisconnected(ParseLiveQueryClient client) {
-            transcript.add("onLiveQueryClientDisconnected");
+        public void onLiveQueryClientDisconnected(ParseLiveQueryClient client, boolean userInitiated) {
+            transcript.add("onLiveQueryClientDisconnected: " + userInitiated);
         }
 
         @Override


### PR DESCRIPTION
First, the close() call was wrong, because the RFC expects a close reason in the 1000-1999 range, but we were passing 200.

I confirmed that changing to `1000` properly closes the socket, and cleans up the connection (which was otherwise causing a memory leak because it didn't close properly).

This also adds the `userInitiated` boolean to the `onLiveQueryClientDisconnected()` callback, so that listeners can choose how to respond based on if it was expected or not (an error disconnect may mean it needs to be reconnected; while an expected disconnect() close should not auto-reconnect)