### PR TITLE
Revert the async disconnect change

### DIFF
--- a/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClient.java
+++ b/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClient.java
@@ -10,6 +10,8 @@ public interface ParseLiveQueryClient {
 
     <T extends ParseObject> void unsubscribe(final ParseQuery<T> query, final SubscriptionHandling<T> subscriptionHandling);
 
+    void connectIfNeeded();
+
     void reconnect();
 
     void disconnect();

--- a/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientImpl.java
+++ b/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientImpl.java
@@ -124,14 +124,12 @@ import static com.parse.Parse.checkInit;
 
     @Override
     public void reconnect() {
-        disconnectAsync().continueWith(new Continuation<Void, Void>() {
-            @Override
-            public Void then(Task<Void> task) throws Exception {
-                webSocketClient = webSocketClientFactory.createInstance(webSocketClientCallback, uri);
-                webSocketClient.open();
-                return null;
-            }
-        });
+        if (webSocketClient != null) {
+            webSocketClient.close();
+        }
+
+        webSocketClient = webSocketClientFactory.createInstance(webSocketClientCallback, uri);
+        webSocketClient.open();
         userInitiatedDisconnect = false;
     }
 
@@ -139,7 +137,8 @@ import static com.parse.Parse.checkInit;
     public void disconnect() {
         if (webSocketClient != null) {
             userInitiatedDisconnect = true;
-            disconnectAsync();
+            webSocketClient.close();
+            webSocketClient = null;
         }
     }
 
@@ -177,20 +176,6 @@ import static com.parse.Parse.checkInit;
                     Log.d(LOG_TAG, "Sending over websocket: " + jsonString);
                 }
                 webSocketClient.send(jsonString);
-                return null;
-            }
-        }, taskExecutor);
-    }
-
-    private Task<Void> disconnectAsync() {
-        return Task.call(new Callable<Void>() {
-            @Override
-            public Void call() throws Exception {
-                if (webSocketClient != null) {
-                    webSocketClient.close();
-                    webSocketClient = null;
-                }
-
                 return null;
             }
         }, taskExecutor);

--- a/ParseLiveQuery/src/test/java/com/parse/ImmediateExecutor.java
+++ b/ParseLiveQuery/src/test/java/com/parse/ImmediateExecutor.java
@@ -1,0 +1,10 @@
+package com.parse;
+
+import java.util.concurrent.Executor;
+
+class ImmediateExecutor implements Executor {
+    @Override
+    public void execute(Runnable runnable) {
+        runnable.run();
+    }
+}

--- a/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
+++ b/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
@@ -390,16 +390,6 @@ public class TestParseLiveQueryClient {
     }
 
     @Test
-    public void testDisconnectOnBackgroundThread() throws Exception {
-        executor.pause();
-
-        parseLiveQueryClient.disconnect();
-        verify(webSocketClient, never()).close();
-        assertTrue(executor.advanceOne());
-        verify(webSocketClient, times(1)).close();
-    }
-
-    @Test
     public void testCallbackNotifiedOnUnexpectedDisconnect() throws Exception {
         LoggingCallbacks callbacks = new LoggingCallbacks();
         parseLiveQueryClient.registerListener(callbacks);


### PR DESCRIPTION
OkHttp WebSocket does all its work on the proper thread, so the async disconnect change is no longer needed.

Since the `disconnectAsync()` change brings up a slew of other issues, it's best to just revert that change (3b0041d).

Closes #37